### PR TITLE
- workaround gcc compiler issue

### DIFF
--- a/src/test/DecompressHelpers_test.cpp
+++ b/src/test/DecompressHelpers_test.cpp
@@ -109,9 +109,9 @@ TEST_CASE("Metadata-fcns", "[small]")
       sizeof(CascadedMetadata),
       sizeof(CascadedMetadata));
 
-  meta_in.setHeader(0, {9, {.i32 = 0u}, 0});
-  meta_in.setHeader(1, {37, {.i32 = 5u}, 3});
-  meta_in.setHeader(2, {49, {.i32 = 2u}, 5});
+  meta_in.setHeader(0, {9, 0, 0});
+  meta_in.setHeader(1, {37, 5, 3});
+  meta_in.setHeader(2, {49, 2, 5});
   meta_in.setDataOffset(0, 10);
   meta_in.setDataOffset(1, 38);
   meta_in.setDataOffset(2, 58);


### PR DESCRIPTION
- initialization of `Header` within `CascadedMetadata` via the union designator results in a gcc internal error. this fix simply specifies the union value without specifying the field name and have it reinterpreted as different types by the `getMinValue...` methods

```
Distributor ID: Ubuntu
Description:    Ubuntu 16.04.6 LTS
Release:        16.04
Codename:       xenial

Thread model: posix
gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.12)

Built on Fri_Feb__8_19:08:17_PST_2019
Cuda compilation tools, release 10.1, V10.1.105

/var/tmp/nvcomp.1/src/test/DecompressHelpers_test.cpp: In function ‘void ____C_A_T_C_H____T_E_S_T____0()’:
/var/tmp/nvcomp.1/src/test/DecompressHelpers_test.cpp:112:43: internal compiler error: in reshape_init_class, at cp/decl.c:5508
   meta_in.setHeader(0, {9, {.i32 = 0u}, 0});
                                           ^
Please submit a full bug report,
with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-5/README.Bugs> for instructions.
src/test/CMakeFiles/DecompressHelpers_test.dir/build.make:62: recipe for target 'src/test/CMakeFiles/DecompressHelpers_test.dir/DecompressHelpers_test.cpp.o' failed
make[2]: *** [src/test/CMakeFiles/DecompressHelpers_test.dir/DecompressHelpers_test.cpp.o] Error 1
```

@nsakharnykh - please review.