### PR TITLE
Add explicit initialization to CascadedMetadata::MinValue union's members.

### DIFF
--- a/src/CascadedMetadata.h
+++ b/src/CascadedMetadata.h
@@ -72,6 +72,8 @@ public:
     uint64_t u64;
   };
 
+  static_assert(std::is_pod<MinValue>::value, "MinValue must be a POD type.");
+
   struct Header
   {
     uint64_t length;

--- a/src/CascadedMetadata.h
+++ b/src/CascadedMetadata.h
@@ -50,20 +50,32 @@ class CascadedMetadata : public Metadata
 public:
   constexpr static const size_t MAX_NUM_RLES = 8;
 
+  union MinValue
+  {
+    MinValue() = default;
+    MinValue(const int8_t num) : i8(num) {}
+    MinValue(const uint8_t num) : u8(num) {}
+    MinValue(const int16_t num) : i16(num) {}
+    MinValue(const uint16_t num) : u16(num) {}
+    MinValue(const int32_t num) : i32(num) {}
+    MinValue(const uint32_t num) : u32(num) {}
+    MinValue(const int64_t num) : i64(num) {}
+    MinValue(const uint64_t num) : u64(num) {}
+
+    int8_t i8;
+    uint8_t u8;
+    int16_t i16;
+    uint16_t u16;
+    int32_t i32;
+    uint32_t u32;
+    int64_t i64;
+    uint64_t u64;
+  };
+
   struct Header
   {
     uint64_t length;
-    union
-    {
-      int8_t i8;
-      uint8_t u8;
-      int16_t i16;
-      uint16_t u16;
-      int32_t i32;
-      uint32_t u32;
-      int64_t i64;
-      uint64_t u64;
-    } minValue;
+    MinValue minValue;
     uint8_t numBits;
   };
 

--- a/src/CascadedMetadata.h
+++ b/src/CascadedMetadata.h
@@ -53,14 +53,30 @@ public:
   union MinValue
   {
     MinValue() = default;
-    MinValue(const int8_t num) : i8(num) {}
-    MinValue(const uint8_t num) : u8(num) {}
-    MinValue(const int16_t num) : i16(num) {}
-    MinValue(const uint16_t num) : u16(num) {}
-    MinValue(const int32_t num) : i32(num) {}
-    MinValue(const uint32_t num) : u32(num) {}
-    MinValue(const int64_t num) : i64(num) {}
-    MinValue(const uint64_t num) : u64(num) {}
+    MinValue(const int8_t num) : i8(num)
+    {
+    }
+    MinValue(const uint8_t num) : u8(num)
+    {
+    }
+    MinValue(const int16_t num) : i16(num)
+    {
+    }
+    MinValue(const uint16_t num) : u16(num)
+    {
+    }
+    MinValue(const int32_t num) : i32(num)
+    {
+    }
+    MinValue(const uint32_t num) : u32(num)
+    {
+    }
+    MinValue(const int64_t num) : i64(num)
+    {
+    }
+    MinValue(const uint64_t num) : u64(num)
+    {
+    }
 
     int8_t i8;
     uint8_t u8;

--- a/src/test/DecompressHelpers_test.cpp
+++ b/src/test/DecompressHelpers_test.cpp
@@ -109,10 +109,9 @@ TEST_CASE("Metadata-fcns", "[small]")
       sizeof(CascadedMetadata),
       sizeof(CascadedMetadata));
 
-
-  meta_in.setHeader(0, {9, 0, 0});
-  meta_in.setHeader(1, {37, 5, 3});
-  meta_in.setHeader(2, {49, 2, 5});
+  meta_in.setHeader(0, {9, {.i32 = 0u}, 0});
+  meta_in.setHeader(1, {37, {.i32 = 5u}, 3});
+  meta_in.setHeader(2, {49, {.i32 = 2u}, 5});
   meta_in.setDataOffset(0, 10);
   meta_in.setDataOffset(1, 38);
   meta_in.setDataOffset(2, 58);

--- a/src/test/DecompressHelpers_test.cpp
+++ b/src/test/DecompressHelpers_test.cpp
@@ -109,9 +109,10 @@ TEST_CASE("Metadata-fcns", "[small]")
       sizeof(CascadedMetadata),
       sizeof(CascadedMetadata));
 
-  meta_in.setHeader(0, {9, {.i32 = 0u}, 0});
-  meta_in.setHeader(1, {37, {.i32 = 5u}, 3});
-  meta_in.setHeader(2, {49, {.i32 = 2u}, 5});
+
+  meta_in.setHeader(0, {9, 0, 0});
+  meta_in.setHeader(1, {37, 5, 3});
+  meta_in.setHeader(2, {49, 2, 5});
   meta_in.setDataOffset(0, 10);
   meta_in.setDataOffset(1, 38);
   meta_in.setDataOffset(2, 58);

--- a/src/test/DecompressHelpers_test.cpp
+++ b/src/test/DecompressHelpers_test.cpp
@@ -109,9 +109,9 @@ TEST_CASE("Metadata-fcns", "[small]")
       sizeof(CascadedMetadata),
       sizeof(CascadedMetadata));
 
-  meta_in.setHeader(0, {9, {.i32 = 0u}, 0});
-  meta_in.setHeader(1, {37, {.i32 = 5u}, 3});
-  meta_in.setHeader(2, {49, {.i32 = 2u}, 5});
+  meta_in.setHeader(0, {9, 0, 0});
+  meta_in.setHeader(1, {37, 5, 3});
+  meta_in.setHeader(2, {49, 2, 5});
   meta_in.setDataOffset(0, 10);
   meta_in.setDataOffset(1, 38);
   meta_in.setDataOffset(2, 58);


### PR DESCRIPTION
closes #1 